### PR TITLE
Fixed reading managed app config pushed by MDM

### DIFF
--- a/ios/RockCheckin.xcodeproj/project.pbxproj
+++ b/ios/RockCheckin.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		9E55AE5B16D88D6200C2CBB1 /* Readme.rtf in Resources */ = {isa = PBXBuildFile; fileRef = 9E55AE5A16D88D6200C2CBB1 /* Readme.rtf */; };
 		9E8C40341975F10A00DC66C4 /* app-notes.txt in Resources */ = {isa = PBXBuildFile; fileRef = 9E8C40331975F10A00DC66C4 /* app-notes.txt */; };
 		9EE5B81E16E457CB00D0D311 /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 9EE5B81D16E457CB00D0D311 /* Settings.bundle */; };
+		FF329D8525BE246800341800 /* SettingsHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = FF329D8425BE246800341800 /* SettingsHelper.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -148,6 +149,8 @@
 		9E55AE5A16D88D6200C2CBB1 /* Readme.rtf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.rtf; path = Readme.rtf; sourceTree = "<group>"; };
 		9E8C40331975F10A00DC66C4 /* app-notes.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "app-notes.txt"; sourceTree = "<group>"; };
 		9EE5B81D16E457CB00D0D311 /* Settings.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Settings.bundle; sourceTree = "<group>"; };
+		FF329D8325BE244500341800 /* SettingsHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SettingsHelper.h; sourceTree = "<group>"; };
+		FF329D8425BE246800341800 /* SettingsHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SettingsHelper.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -213,6 +216,8 @@
 				6591E2A723E61A3A006B38F0 /* InitialSetupViewController.xib */,
 				65C56F4123E7918E004C265F /* WKWebViewUIDelegate.h */,
 				65C56F4223E7918E004C265F /* WKWebViewUIDelegate.m */,
+				FF329D8325BE244500341800 /* SettingsHelper.h */,
+				FF329D8425BE246800341800 /* SettingsHelper.m */,
 			);
 			name = Classes;
 			path = RockCheckin/Classes;
@@ -455,6 +460,7 @@
 				9E55AE4716D88BD700C2CBB1 /* SBJsonStreamWriter.m in Sources */,
 				9E55AE4816D88BD700C2CBB1 /* SBJsonStreamWriterAccumulator.m in Sources */,
 				9E55AE4916D88BD700C2CBB1 /* SBJsonStreamWriterState.m in Sources */,
+				FF329D8525BE246800341800 /* SettingsHelper.m in Sources */,
 				9E55AE4A16D88BD700C2CBB1 /* SBJsonTokeniser.m in Sources */,
 				9E55AE4B16D88BD700C2CBB1 /* SBJsonUTF8Stream.m in Sources */,
 				9E55AE4C16D88BD700C2CBB1 /* SBJsonWriter.m in Sources */,

--- a/ios/RockCheckin/Classes/AppDelegate.m
+++ b/ios/RockCheckin/Classes/AppDelegate.m
@@ -32,6 +32,7 @@
 #import "RKBLEZebraPrint.h"
 #import "SettingsViewController.h"
 #import "InitialSetupViewController.h"
+#import "SettingsHelper.h"
 
 static AppDelegate *_sharedDelegate = nil;
 
@@ -79,9 +80,9 @@ static AppDelegate *_sharedDelegate = nil;
  */
 - (void)defaultsChangedNotification:(NSNotification *)notification
 {
-    NSString *printerName = [[NSUserDefaults standardUserDefaults] stringForKey:@"printer_override"];
+    NSString *printerName = [SettingsHelper stringForKey:@"printer_override"];
     
-    if (printerName != nil && printerName.length > 0 && [NSUserDefaults.standardUserDefaults boolForKey:@"bluetooth_printing"]) {
+    if (printerName != nil && printerName.length > 0 && [SettingsHelper boolForKey:@"bluetooth_printing"]) {
         if (![printerName isEqualToString:self.blePrinter.printerName]) {
             [self.blePrinter setPrinterName:printerName];
         }
@@ -118,15 +119,6 @@ static AppDelegate *_sharedDelegate = nil;
     }
     
     [NSUserDefaults.standardUserDefaults registerDefaults:defaultValues];
-
-    // Set any settings pushed from MDM
-    NSDictionary *serverConfig = [NSUserDefaults.standardUserDefaults dictionaryForKey:@"com.apple.configuration.managed"];
-    if(serverConfig == nil) {
-        serverConfig = @{};
-    }
-    for(id key in serverConfig) {
-        [NSUserDefaults.standardUserDefaults setObject:[serverConfig objectForKey:key] forKey:key];
-    }
 }
 
 
@@ -165,8 +157,8 @@ static AppDelegate *_sharedDelegate = nil;
     // Bluetooth Printing is enabled.
     //
     self.blePrinter = [[RKBLEZebraPrint alloc] init];
-    NSString *printerName = [[NSUserDefaults standardUserDefaults] stringForKey:@"printer_override"];
-    if (printerName != nil && printerName.length > 0 && [NSUserDefaults.standardUserDefaults boolForKey:@"bluetooth_printing"])
+    NSString *printerName = [SettingsHelper stringForKey:@"printer_override"];
+    if (printerName != nil && printerName.length > 0 && [SettingsHelper boolForKey:@"bluetooth_printing"])
     {
         [self.blePrinter setPrinterName:printerName];
     }

--- a/ios/RockCheckin/Classes/AppDelegate.m
+++ b/ios/RockCheckin/Classes/AppDelegate.m
@@ -118,6 +118,15 @@ static AppDelegate *_sharedDelegate = nil;
     }
     
     [NSUserDefaults.standardUserDefaults registerDefaults:defaultValues];
+
+    // Set any settings pushed from MDM
+    NSDictionary *serverConfig = [NSUserDefaults.standardUserDefaults dictionaryForKey:@"com.apple.configuration.managed"];
+    if(serverConfig == nil) {
+        serverConfig = @{};
+    }
+    for(id key in serverConfig) {
+        [NSUserDefaults.standardUserDefaults setObject:[serverConfig objectForKey:key] forKey:key];
+    }
 }
 
 

--- a/ios/RockCheckin/Classes/CameraViewController.m
+++ b/ios/RockCheckin/Classes/CameraViewController.m
@@ -29,6 +29,7 @@ under the License.
 #import "UIColor+HexString.h"
 #import "ZebraPrint.h"
 #import <AVFoundation/AVFoundation.h>
+#import "SettingsHelper.h"
 
 @interface CameraViewController () <AVCaptureMetadataOutputObjectsDelegate>
 
@@ -80,8 +81,7 @@ under the License.
     //
     // Set the color of the button text and border.
     //
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    NSString *colorString = [defaults stringForKey:@"ui_foreground_color"];
+    NSString *colorString = [SettingsHelper stringForKey:@"ui_foreground_color"];
     UIColor *color = [UIColor colorWithHexString:colorString];
     if (color != nil) {
         [self.cancelButton setTitleColor:color forState:UIControlStateNormal];
@@ -91,7 +91,7 @@ under the License.
     //
     // Set the color of the header background.
     //
-    colorString = [defaults stringForKey:@"ui_background_color"];
+    colorString = [SettingsHelper stringForKey:@"ui_background_color"];
     color = [UIColor colorWithHexString:colorString];
     if (color != nil) {
         self.headerView.backgroundColor = color;
@@ -266,9 +266,8 @@ Stop the camera and cease watching for barcodes.
 {
     [self verifyCameraPermission:^(BOOL success) {
         AVCaptureDevice *device = nil;
-        NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-        NSString *position = [defaults stringForKey:@"camera_position"];
-        float exposure = [defaults floatForKey:@"camera_exposure"];
+        NSString *position = [SettingsHelper stringForKey:@"camera_position"];
+        float exposure = [SettingsHelper floatForKey:@"camera_exposure"];
 
         //
         // Open either the front or rear camera. Later we may want to add

--- a/ios/RockCheckin/Classes/InitialSetupViewController.m
+++ b/ios/RockCheckin/Classes/InitialSetupViewController.m
@@ -7,6 +7,7 @@
 
 #import "InitialSetupViewController.h"
 #import "MainViewController.h"
+#import "SettingsHelper.h"
 
 @interface InitialSetupViewController () <MainReadyDelegate>
 
@@ -60,7 +61,7 @@
     if (self.isFirstDisplay) {
         self.isFirstDisplay = NO;
 
-        NSString *url = [NSUserDefaults.standardUserDefaults stringForKey:@"checkin_address"];
+        NSString *url = [SettingsHelper stringForKey:@"checkin_address"];
         if (url != nil && url.length > 0) {
             [self showLoadingView];
         }
@@ -106,7 +107,7 @@
 
 - (void)showConfigView
 {
-    NSString *url = [NSUserDefaults.standardUserDefaults stringForKey:@"checkin_address"];
+    NSString *url = [SettingsHelper stringForKey:@"checkin_address"];
     self.urlField.text = url;
     
     self.loadingView.hidden = YES;
@@ -117,7 +118,7 @@
 
 - (void)showLoadingView
 {
-    NSString *url = [NSUserDefaults.standardUserDefaults stringForKey:@"checkin_address"];
+    NSString *url = [SettingsHelper stringForKey:@"checkin_address"];
     __auto_type text = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:@"Loading check-in from\n%@", url]];
     [text addAttribute:NSFontAttributeName
                  value:[UIFont fontWithName:@"OpenSans-Semibold" size:self.loadingFromUrl.font.pointSize]
@@ -151,7 +152,7 @@
  */
 - (void)showLoadingError
 {
-    NSString *url = [NSUserDefaults.standardUserDefaults stringForKey:@"checkin_address"];
+    NSString *url = [SettingsHelper stringForKey:@"checkin_address"];
     __auto_type text = [[NSMutableAttributedString alloc] initWithString:[NSString stringWithFormat:@"Could not load check-in from\n%@", url]];
     [text addAttribute:NSFontAttributeName
                  value:[UIFont fontWithName:@"OpenSans-Semibold" size:self.loadErrorUrl.font.pointSize]

--- a/ios/RockCheckin/Classes/MainViewController.m
+++ b/ios/RockCheckin/Classes/MainViewController.m
@@ -33,6 +33,7 @@
 #import "WKWebViewUIDelegate.h"
 #import "ZebraPrint.h"
 #import <WebKit/WebKit.h>
+#import "SettingsHelper.h"
 
 @interface MainViewController () <UIGestureRecognizerDelegate, WKNavigationDelegate, CameraViewControllerDelegate>
 
@@ -94,8 +95,8 @@
 {
     [super viewDidLoad];
     
-    self.settingsGestureRecognizer.enabled = [NSUserDefaults.standardUserDefaults boolForKey:@"in_app_settings"];
-    self.settingsGestureRecognizer.minimumPressDuration = [NSUserDefaults.standardUserDefaults integerForKey:@"in_app_settings_delay"];
+    self.settingsGestureRecognizer.enabled = [SettingsHelper boolForKey:@"in_app_settings"];
+    self.settingsGestureRecognizer.minimumPressDuration = [SettingsHelper integerForKey:@"in_app_settings_delay"];
 
     [NSNotificationCenter.defaultCenter addObserver:self
                                            selector:@selector(defaultsChangedNotification:)
@@ -118,7 +119,7 @@
  */
 - (void)reloadCheckinAddress
 {
-    NSURL *url = [NSURL URLWithString:[NSUserDefaults.standardUserDefaults objectForKey:@"checkin_address"]];
+    NSURL *url = [NSURL URLWithString:[SettingsHelper objectForKey:@"checkin_address"]];
     
     NSURLRequest *request = [NSURLRequest requestWithURL:url];
     
@@ -193,8 +194,8 @@
  */
 - (void)defaultsChangedNotification:(NSNotification *)notification
 {
-    self.settingsGestureRecognizer.enabled = [NSUserDefaults.standardUserDefaults boolForKey:@"in_app_settings"];
-    self.settingsGestureRecognizer.minimumPressDuration = [NSUserDefaults.standardUserDefaults integerForKey:@"in_app_settings_delay"];
+    self.settingsGestureRecognizer.enabled = [SettingsHelper boolForKey:@"in_app_settings"];
+    self.settingsGestureRecognizer.minimumPressDuration = [SettingsHelper integerForKey:@"in_app_settings_delay"];
 }
 
 /**
@@ -337,7 +338,7 @@
  */
 - (void)cameraViewController:(CameraViewController *)controller didScanPreCheckInCode:(NSString *)code completedCallback:(void (^)(NSString *))callback
 {
-    NSURLComponents *urlComponents = [NSURLComponents componentsWithString:[NSUserDefaults.standardUserDefaults objectForKey:@"checkin_address"]];
+    NSURLComponents *urlComponents = [NSURLComponents componentsWithString:[SettingsHelper objectForKey:@"checkin_address"]];
     urlComponents.path = @"/api/checkin/printsessionlabels";
     NSURLQueryItem *kioskIdParam = [NSURLQueryItem  queryItemWithName:@"kioskId" value:[NSString stringWithFormat:@"%d", self.kioskId]];
     NSURLQueryItem *sessionParam = [NSURLQueryItem queryItemWithName:@"session" value:code];

--- a/ios/RockCheckin/Classes/SettingsHelper.h
+++ b/ios/RockCheckin/Classes/SettingsHelper.h
@@ -1,0 +1,29 @@
+// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SettingsHelper : NSObject
+
++ (id)objectForKey: (NSString*) key;
++ (bool)boolForKey: (NSString*) key;
++ (float)floatForKey: (NSString*) key;
++ (int)integerForKey: (NSString*) key;
++ (NSString*)stringForKey: (NSString*) key;
++ (bool)objectIsForcedForKey: (NSString*) key;
+
+@end

--- a/ios/RockCheckin/Classes/SettingsHelper.m
+++ b/ios/RockCheckin/Classes/SettingsHelper.m
@@ -1,0 +1,65 @@
+// <copyright>
+// Copyright by the Spark Development Network
+//
+// Licensed under the Rock Community License (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.rockrms.com/license
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+//
+
+#import "SettingsHelper.h"
+
+@implementation SettingsHelper
+
++ (id)objectForKey: (NSString*) key {
+
+    // Check for settings pushed from MDM
+    NSDictionary *serverConfig = [NSUserDefaults.standardUserDefaults dictionaryForKey:@"com.apple.configuration.managed"];
+    if(serverConfig == nil) {
+        serverConfig = @{};
+    }
+
+    if ([serverConfig objectForKey:key] != nil) {
+        return [serverConfig objectForKey:key];
+    }
+    else {
+        return [NSUserDefaults.standardUserDefaults objectForKey:key];
+    }
+}
+
++ (bool)boolForKey: (NSString*) key {
+    NSNumber *result = [SettingsHelper objectForKey:key];
+    return [result boolValue];
+}
+
++ (float)floatForKey: (NSString*) key {
+    NSNumber *result = [SettingsHelper objectForKey:key];
+    return [result floatValue];
+}
+
++ (int)integerForKey: (NSString*) key {
+    NSNumber *result = [SettingsHelper objectForKey:key];
+    return [result intValue];
+}
+
++ (NSString*)stringForKey: (NSString*) key {
+    return [SettingsHelper objectForKey:key];
+}
+
++ (bool)objectIsForcedForKey: (NSString*) key {
+    NSDictionary *serverConfig = [NSUserDefaults.standardUserDefaults dictionaryForKey:@"com.apple.configuration.managed"];
+    if(serverConfig == nil) {
+        serverConfig = @{};
+    }
+    return ([serverConfig objectForKey:key] != nil || [NSUserDefaults.standardUserDefaults objectIsForcedForKey:key]);
+}
+
+@end

--- a/ios/RockCheckin/Classes/SettingsViewController.m
+++ b/ios/RockCheckin/Classes/SettingsViewController.m
@@ -111,17 +111,54 @@
     // Handle any MDM forced settings so the user can't change them.
     //
     NSUserDefaults *defaults = NSUserDefaults.standardUserDefaults;
-    self.checkinAddress.enabled = ![defaults objectIsForcedForKey:@"checkin_address"];
-    self.enableLabelCaching.enabled = ![defaults objectIsForcedForKey:@"enable_caching"];
-    self.cacheDuration.enabled = ![defaults objectIsForcedForKey:@"cache_duration"];
-    self.enableLabelCutting.enabled = ![defaults objectIsForcedForKey:@"enable_label_cutting"];
-    self.cameraPosition.enabled = ![defaults objectIsForcedForKey:@"camera_position"];
-    self.cameraExposure.enabled = ![defaults objectIsForcedForKey:@"camera_exposure"];
-    self.uiBackgroundColor.enabled = ![defaults objectIsForcedForKey:@"ui_background_color"];
-    self.uiForegroundColor.enabled = ![defaults objectIsForcedForKey:@"ui_foreground_color"];
-    self.printerOverride.enabled = ![defaults objectIsForcedForKey:@"printer_override"];
-    self.printerTimeout.enabled = ![defaults objectIsForcedForKey:@"printer_timeout"];
-    self.bluetoothPrinting.enabled = ![defaults objectIsForcedForKey:@"bluetooth_printing"];
+    NSDictionary *serverConfig = [NSUserDefaults.standardUserDefaults dictionaryForKey:@"com.apple.configuration.managed"];
+    if(serverConfig == nil) {
+        serverConfig = @{};
+    }
+    if([serverConfig objectForKey:@"checkin_address"] || [defaults objectIsForcedForKey:@"checkin_address"]) {
+        self.checkinAddress.enabled = NO;
+        self.checkinAddress.alpha = 0.4;
+    }
+    if([serverConfig objectForKey:@"enable_caching"] || [defaults objectIsForcedForKey:@"enable_caching"]) {
+        self.enableLabelCaching.enabled = NO;
+        self.enableLabelCaching.alpha = 0.4;
+    }
+    if([serverConfig objectForKey:@"cache_duration"] || [defaults objectIsForcedForKey:@"cache_duration"]) {
+        self.cacheDuration.enabled = NO;
+        self.cacheDuration.alpha = 0.4;
+    }
+    if([serverConfig objectForKey:@"enable_label_cutting"] || [defaults objectIsForcedForKey:@"enable_label_cutting"]) {
+        self.enableLabelCutting.enabled = NO;
+        self.enableLabelCutting.alpha = 0.4;
+    }
+    if([serverConfig objectForKey:@"camera_position"] || [defaults objectIsForcedForKey:@"camera_position"]) {
+        self.cameraPosition.enabled = NO;
+        self.cameraPosition.alpha = 0.4;
+    }
+    if([serverConfig objectForKey:@"camera_exposure"] || [defaults objectIsForcedForKey:@"camera_exposure"]) {
+        self.cameraExposure.enabled = NO;
+        self.cameraExposure.alpha = 0.4;
+    }
+    if([serverConfig objectForKey:@"ui_background_color"] || [defaults objectIsForcedForKey:@"ui_background_color"]) {
+        self.uiBackgroundColor.enabled = NO;
+        self.uiBackgroundColor.alpha = 0.4;
+    }
+    if([serverConfig objectForKey:@"ui_foreground_color"] || [defaults objectIsForcedForKey:@"ui_foreground_color"]) {
+        self.uiForegroundColor.enabled = NO;
+        self.uiForegroundColor.alpha = 0.4;
+    }
+    if([serverConfig objectForKey:@"printer_override"] || [defaults objectIsForcedForKey:@"printer_override"]) {
+        self.printerOverride.enabled = NO;
+        self.printerOverride.alpha = 0.4;
+    }
+    if([serverConfig objectForKey:@"printer_timeout"] || [defaults objectIsForcedForKey:@"printer_timeout"]) {
+        self.printerTimeout.enabled = NO;
+        self.printerTimeout.alpha = 0.4;
+    }
+    if([serverConfig objectForKey:@"bluetooth_printing"] || [defaults objectIsForcedForKey:@"bluetooth_printing"]) {
+        self.bluetoothPrinting.enabled = NO;
+        self.bluetoothPrinting.alpha = 0.4;
+    }
 
     if (self.bluetoothPrinting.on) {
         self.centralManager = [[CBCentralManager alloc] initWithDelegate:self queue:nil];

--- a/ios/RockCheckin/Classes/ZebraPrint.m
+++ b/ios/RockCheckin/Classes/ZebraPrint.m
@@ -13,6 +13,7 @@
 #import "SBJson.h"
 #import "EGOCache.h"
 #import "AppDelegate.h"
+#import "SettingsHelper.h"
 
 
 @implementation ZebraPrint
@@ -24,9 +25,8 @@ Process a Javascript request to print the label tags.
 */
 - (NSString *)printJsonTags:(NSString *)jsonString
 {
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     BOOL labelErrorOccurred = NO;
-    BOOL enableLabelCutting = [defaults boolForKey:@"enable_label_cutting"];
+    BOOL enableLabelCutting = [SettingsHelper boolForKey:@"enable_label_cutting"];
     NSString *errorMessage = nil;
     
     NSLog(@"[LOG] ZebraPrint Plugin Called");
@@ -68,14 +68,14 @@ Process a Javascript request to print the label tags.
                     labelIndex += 1;
                     
                     // change printer ip if printer overide setting is present
-                    NSString *overridePrinter = [defaults stringForKey:@"printer_override"];
+                    NSString *overridePrinter = [SettingsHelper stringForKey:@"printer_override"];
                     
                     if (overridePrinter != nil && overridePrinter.length > 0) {
                         printerAddress = overridePrinter;
                     }
                     
                     // Set printer timeout value
-                    NSString *printerTimeoutString = [defaults stringForKey:@"printer_timeout"];
+                    NSString *printerTimeoutString = [SettingsHelper stringForKey:@"printer_timeout"];
                     
                     if (printerTimeoutString != nil && printerTimeoutString.intValue > 0) {
                         printerTimeout = printerTimeoutString.intValue;
@@ -143,7 +143,7 @@ Process a Javascript request to print the label tags.
                         }
                         
                         NSLog(@"Printing label: %@", mergedLabel);
-                        if ([NSUserDefaults.standardUserDefaults boolForKey:@"bluetooth_printing"])
+                        if ([SettingsHelper boolForKey:@"bluetooth_printing"])
                         {
                             RKBLEZebraPrint *printer = AppDelegate.sharedDelegate.blePrinter;
                             BOOL success = [printer print:mergedLabel];
@@ -261,8 +261,7 @@ Process a Javascript request to print the label tags.
 - (NSString*)getLabelContents:(NSString*)labelKey labelLocation:(NSString*)labelFile
 {
     // determine cache preference
-    NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
-    BOOL usecache = [defaults boolForKey:@"enable_caching"];
+    BOOL usecache = [SettingsHelper boolForKey:@"enable_caching"];
     
     NSString *labelContents = nil;
     
@@ -295,7 +294,7 @@ Process a Javascript request to print the label tags.
             // store label file in cache
             if (usecache) {
             
-                NSString *cacheDuration = [defaults stringForKey:@"cache_duration"];
+                NSString *cacheDuration = [SettingsHelper stringForKey:@"cache_duration"];
                 NSScanner *scanner = [NSScanner scannerWithString:cacheDuration ];
                 
                 double doubleCacheDuration;


### PR DESCRIPTION
## Proposed Changes

The app was not responding to any settings that I pushed from my MDM (Mosyle). I originally thought it was just a Mosyle issue, but someone in chat was also having trouble with a different MDM. After these changes I can push app settings from Mosyle, and they will take effect after the next app restart. 

This PR adds code to loop through any managed app config settings on startup and save them to NSUserDefaults. I didn't think reloading whenever new settings come in was a good idea since someone could be in the middle of checking in, so I opted for only reading the settings when the app restarts.

I also modified the code to disable edit controls for any pre-configured settings to "grey out" any settings that were disabled. Before, there was no visual difference between enabled and disabled controls, which could be confusing for a user trying to edit the settings.

Fixes: #NA

## Types of changes

What types of changes does your code introduce to Rock?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality, which has been approved by the core team)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] This is a single-commit PR. (If not, please squash your commit and re-submit it.)
- [x] I verified my PR does not include whitespace/formatting changes -- because if it does it will be closed without merging.	
- [x] I have read the [Contributing to Rock](https://github.com/SparkDevNetwork/Rock/blob/master/.github/CONTRIBUTING.md) doc
- [x] By contributing code, I agree to license my contribution under the [Rock Community License Agreement](https://www.rockrms.com/license)
- [ ] Unit tests pass locally with my changes
- [ ] I have added [required tests](https://github.com/SparkDevNetwork/Rock/blob/develop/Rock.Tests/README.md) that prove my fix is effective or that my feature works
- [ ] I have included updated language for the [Rock Documentation](https://www.rockrms.com/Learn/Documentation) (if appropriate)

## Further comments
*Note*: Although I couldn't find any recent documentation on `objectIsForcedForKey`, I left those checks in there anyway so as to not mess it up for anyone that is setting the defaults that way.

I have tested this with Mosyle, and it works. I do not have access to any other MDM to test on but I don't see why it would be any different since managed app config is an Apple standard.

Code is based on this example from Apple for how to read managed app config: https://developer.apple.com/library/archive/samplecode/sc2279/Introduction/Intro.html

For reference, here is an example of what I am sending from Mosyle in order to set the checkin address and printer override:
```
<dict>
    <key>checkin_address</key>
    <string>https://rock.rocksolidchurchdemo.com/checkin</string>
    <key>printer_override</key>
    <string>172.20.3.219</string>
</dict>
```