### PR TITLE
Increase allowableMovement for five finger menu

### DIFF
--- a/ios/RockCheckin/Classes/MainViewController.xib
+++ b/ios/RockCheckin/Classes/MainViewController.xib
@@ -23,7 +23,7 @@
             </connections>
             <point key="canvasLocation" x="453.51562499999994" y="251.5625"/>
         </view>
-        <pongPressGestureRecognizer allowableMovement="10" minimumPressDuration="1" numberOfTouchesRequired="5" id="Iki-YV-Akd">
+        <pongPressGestureRecognizer allowableMovement="100" minimumPressDuration="1" numberOfTouchesRequired="5" id="Iki-YV-Akd">
             <connections>
                 <action selector="showSettingsViewController:" destination="-1" id="6XL-n4-MHB"/>
             </connections>


### PR DESCRIPTION
Hey there!  My church has had some trouble getting this menu to consistently appear using the five finger command.  As far as I can tell, increasing the allowableMovement here shouldn't be detrimental since it's unlikely someone will accidentally press the screen with five fingers.  I'm hoping increased allowableMovement would make the menu command work more consistently.  Does that seem reasonable?  Thanks!